### PR TITLE
Updated compare-git-hashes to do the checkout of submodules. Script now accepts stan_pr and math_pr

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,12 @@
 import org.stan.Utils
 
 def utils = new org.stan.Utils()
-def branch = ''
 
 pipeline {
     agent { label 'gelman-group-mac' }
+    environment {
+        branch = ""
+    }
     options {
         skipDefaultCheckout()
         preserveStashes(buildCount: 7)

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,8 +13,8 @@ pipeline {
     }
     parameters {
         string(defaultValue: '', name: 'cmdstan_pr', description: "CmdStan hash/branch to compare against")
-        string(defaultValue: '', name: 'stan_pr', description: "Stan PR to test against. Will check out this PR in the downstream Stan repo")
-        string(defaultValue: '', name: 'math_pr', description: "Math PR to test against. Will check out this PR in the downstream Math repo")
+        string(defaultValue: '', name: 'stan_pr', description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
+        string(defaultValue: '', name: 'math_pr', description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
     }
     stages {
         stage('Clean checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,12 +12,9 @@ pipeline {
         preserveStashes(buildCount: 7)
     }
     parameters {
-        string(defaultValue: '', name: 'cmdstan_pr',
-               description: "CmdStan hash/branch to compare against")
-        string(defaultValue: '', name: 'stan_pr',
-               description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
-        string(defaultValue: '', name: 'math_pr',
-               description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
+        string(defaultValue: '', name: 'cmdstan_pr', description: "CmdStan hash/branch to compare against")
+        string(defaultValue: '', name: 'stan_pr', description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
+        string(defaultValue: '', name: 'math_pr', description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
     }
     stages {
         stage('Clean checkout') {
@@ -74,15 +71,15 @@ pipeline {
                     else{
                         branch = params.cmdstan_pr
                     }
-                }
 
-                sh """       
-                old_hash=\$(git submodule status | grep cmdstan | awk '{print \$1}')
-                cmdstan_hash=\$(if [ -n "${branch}" ]; then echo "${branch}"; else echo "\$old_hash" ; fi)
-                bash compare-git-hashes.sh develop \$cmdstan_hash stat_comp_benchmarks false
-                mv performance.xml \$cmdstan_hash.xml
-                make revert clean
-            """
+                    sh """       
+                        old_hash=\$(git submodule status | grep cmdstan | awk '{print \$1}')
+                        cmdstan_hash=\$(if [ -n "${branch}" ]; then echo "${branch}"; else echo "\$old_hash" ; fi)
+                        bash compare-git-hashes.sh develop \$cmdstan_hash stat_comp_benchmarks false
+                        mv performance.xml \$cmdstan_hash.xml
+                        make revert clean
+                    """
+                }
             }
         }
         stage("Numerical Accuracy and Performance Tests on Known-Good Models") {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 import org.stan.Utils
 
 def utils = new org.stan.Utils()
-def branch = ""
+def branch = ''
 
 pipeline {
     agent { label 'gelman-group-mac' }
@@ -13,8 +13,8 @@ pipeline {
     }
     parameters {
         string(defaultValue: '', name: 'cmdstan_pr', description: "CmdStan hash/branch to compare against")
-        string(defaultValue: '', name: 'stan_pr', description: "Stan PR to test against. Will check out this PR in the downstream Stan repo.")
-        string(defaultValue: '', name: 'math_pr', description: "Math PR to test against. Will check out this PR in the downstream Math repo.")
+        string(defaultValue: '', name: 'stan_pr', description: "Stan PR to test against. Will check out this PR in the downstream Stan repo")
+        string(defaultValue: '', name: 'math_pr', description: "Math PR to test against. Will check out this PR in the downstream Math repo")
     }
     stages {
         stage('Clean checkout') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -73,7 +73,7 @@ pipeline {
                         sh """       
                             old_hash=\$(git submodule status | grep cmdstan | awk '{print \$1}')
                             cmdstan_hash=\$(if [ -n "${cmdstan_pr}" ]; then echo "${cmdstan_pr}"; else echo "\$old_hash" ; fi)
-                            bash compare-git-hashes.sh develop \$cmdstan_hash stat_comp_benchmarks ${branchOrPR(params.stan_pr)} ${branchOrPR(params.math_pr)} false
+                            bash compare-git-hashes.sh develop \$cmdstan_hash stat_comp_benchmarks ${branchOrPR(params.stan_pr)} ${branchOrPR(params.math_pr)}
                             mv performance.xml \$cmdstan_hash.xml
                             make revert clean
                         """

--- a/compare-git-hashes.sh
+++ b/compare-git-hashes.sh
@@ -3,7 +3,7 @@
 usage() {
     echo "=====!!!WARNING!!!===="
     echo "This will clean all repos involved! Use only on a clean checkout."
-    echo "$0 <git-hash-1> <git-hash-2> <directories of models> <stan_pr> <math_pr> <do submodule update (false|true)> <extra args for runPerformanceTests.py>'"
+    echo "$0 <git-hash-1> <git-hash-2> <directories of models> <stan_pr> <math_pr> <extra args for runPerformanceTests.py>'"
     echo "(those last extra args are in quotes)"
 }
 
@@ -25,33 +25,29 @@ clean_checkout() {
 		git checkout "$1"
 	fi
 
-    if [[ "$6" != "false" ]] ; then
-        git submodule update --init --recursive
-    else
-        #Checkout stan
-        cd stan
-        if [[ "$4" == "PR-"* ]] ; then
-            prNumber=$(echo $4 | cut -d "-" -f 2)
-	    	git fetch https://github.com/stan-dev/stan +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
-            git checkout refs/remotes/origin/pr/$prNumber/merge
-	    else
-	    	git checkout $4 && git pull origin $4
-	    fi
-        #cd stan && git clean -xffd
-	    cd ..
-    
-        #Checkout math
-        pushd stan/lib/stan_math
-        if [[ "$5" == "PR-"* ]] ; then
-            prNumber=$(echo $5 | cut -d "-" -f 2)
-	    	git fetch https://github.com/stan-dev/math +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
-            git checkout refs/remotes/origin/pr/$prNumber/merge
-	    else
-	    	git checkout $5 && git pull origin $5
-	    fi
-        #cd stan/lib/stan_math && git clean -xffd
-	    popd
-    fi
+    #Checkout stan
+    cd stan
+    if [[ "$4" == "PR-"* ]] ; then
+        prNumber=$(echo $4 | cut -d "-" -f 2)
+		git fetch https://github.com/stan-dev/stan +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
+        git checkout refs/remotes/origin/pr/$prNumber/merge
+	else
+		git checkout $4 && git pull origin $4
+	fi
+    #cd stan && git clean -xffd
+	cd ..
+
+    #Checkout math
+    pushd stan/lib/stan_math
+    if [[ "$5" == "PR-"* ]] ; then
+        prNumber=$(echo $5 | cut -d "-" -f 2)
+		git fetch https://github.com/stan-dev/math +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
+        git checkout refs/remotes/origin/pr/$prNumber/merge
+	else
+		git checkout $5 && git pull origin $5
+	fi
+    #cd stan/lib/stan_math && git clean -xffd
+	popd
     
     cd ..
     make clean

--- a/compare-git-hashes.sh
+++ b/compare-git-hashes.sh
@@ -3,7 +3,7 @@
 usage() {
     echo "=====!!!WARNING!!!===="
     echo "This will clean all repos involved! Use only on a clean checkout."
-    echo "$0 <git-hash-1> <git-hash-2> <directories of models> <do submodule update (false|true)> <extra args for runPerformanceTests.py>'"
+    echo "$0 <git-hash-1> <git-hash-2> <directories of models> <stan_pr> <math_pr> <do submodule update (false|true)> <extra args for runPerformanceTests.py>'"
     echo "(those last extra args are in quotes)"
 }
 
@@ -15,7 +15,8 @@ clean_checkout() {
     make revert
 	
 	cd cmdstan
-	
+
+    #Checkout CmdStan
 	if [[ "$1" == "PR-"* ]] ; then
         prNumber=$(echo $1 | cut -d "-" -f 2)
 		git fetch https://github.com/stan-dev/cmdstan +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
@@ -24,8 +25,32 @@ clean_checkout() {
 		git checkout "$1"
 	fi
 
-    if [[ "$4" != "false" ]] ; then
+    if [[ "$6" != "false" ]] ; then
         git submodule update --init --recursive
+    else
+        #Checkout stan
+        cd stan
+        if [[ "$4" == "PR-"* ]] ; then
+            prNumber=$(echo $4 | cut -d "-" -f 2)
+	    	git fetch https://github.com/stan-dev/stan +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
+            git checkout refs/remotes/origin/pr/$prNumber/merge
+	    else
+	    	git checkout $4 && git pull origin $4
+	    fi
+        #cd stan && git clean -xffd
+	    cd ..
+    
+        #Checkout math
+        pushd stan/lib/stan_math
+        if [[ "$5" == "PR-"* ]] ; then
+            prNumber=$(echo $5 | cut -d "-" -f 2)
+	    	git fetch https://github.com/stan-dev/math +refs/pull/$prNumber/merge:refs/remotes/origin/pr/$prNumber/merge
+            git checkout refs/remotes/origin/pr/$prNumber/merge
+	    else
+	    	git checkout $5 && git pull origin $5
+	    fi
+        #cd stan/lib/stan_math && git clean -xffd
+	    popd
     fi
     
     cd ..


### PR DESCRIPTION
Updated compare-git-hashes to do the checkout of submodules. 
Script now accepts stan_pr and math_pr arguments and will checkout them properly. 
Refactored Jenkinsfile a little.
 Jenkinsfile will take care of exceptions like downstream_tests for example.