### PR TITLE
Dont run tests with integrate temporarily

### DIFF
--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -9,6 +9,4 @@ stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
 stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
 stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
 stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
-stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
-stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
 stat_comp_benchmarks/benchmarks/sir/sir.stan


### PR DESCRIPTION
A fix to merge stan-dev/math#1641

The issue is that the golds (calculated with develop) differ too much, due to the changes in default. We checked that the PR is fine. 
Will revert this after the PR is merged