### PR TITLE
Refactor runPerformanceTests.py

### DIFF
--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -416,7 +416,7 @@ if __name__ == "__main__":
              for model, exe, ns in zip(models, executables, num_samples)]
 
     for batch in batched(executables):
-        make_time, _ = time_step("make_all_models", make, executables, args.j)
+        make_time, _ = time_step("make_all_models", make, batch, args.j)
 
     if args.runj > 1:
         tp = ThreadPool(args.runj)

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -340,6 +340,7 @@ def parse_args():
                         help="Number of samples to ask Stan programs for if we're sampling.")
     parser.add_argument("--tests-file", dest="tests", action="store", type=str, default="")
     parser.add_argument("--scorch-earth", dest="scorch", action="store_true")
+    parser.add_argument("--no-ignore-models", dest="no_ignore_models", action="store_true")
     return parser.parse_args()
 
 def process_test(overwrite, check_golds, check_golds_exact, runs, method):
@@ -381,11 +382,13 @@ if __name__ == "__main__":
         models = find_files("*.stan", args.directories)
         models = filter(model_name_re.match, models)
         models = list(filter(lambda m: not m in bad_models, models))
-        models = filter_out_weekly_models(models)
+        if not args.no_ignore_models:
+            models = filter_out_weekly_models(models)
         num_samples = [args.num_samples or default_num_samples] * len(models)
     else:
         models, num_samples = read_tests(args.tests, args.num_samples or default_num_samples)
-        models = filter_out_weekly_models(models)
+        if not args.no_ignore_models:
+            models = filter_out_weekly_models(models)
         if args.num_samples:
             num_samples = [args.num_samples] * len(models)
 

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -262,6 +262,8 @@ def run_golds(gold, tmp, summary, check_golds_exact):
 
 def run(exe, data, overwrite, check_golds, check_golds_exact, runs, method, num_samples):
     fails, errors = [], []
+    if sys.platform.startswith('win'):
+        exe = exe + ".exe"
     if not os.path.isfile(exe):
         return 0, (fails, errors + ["Did not compile!"])
     if runs <= 0:

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -148,6 +148,14 @@ bad_models = frozenset(
      , os.path.join("example-models","BPA","Ch.07","cjs_group_raneff.stan")
     ])
 
+weekly_test_only = frozenset(
+    [os.path.join("good","function-signatures","distributions","univariate","continuous", "exp_mod_normal")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "pareto_type_2")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "skew_normal")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "student_t")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "wiener")
+    ])
+
 def avg(coll):
     return float(sum(coll)) / len(coll)
 
@@ -351,6 +359,18 @@ def delete_temporary_exe_files(exes):
             if os.path.exists(exe + ext):
                 os.remove(exe + ext)
 
+def filter_out_weekly_models(models):
+    ret_models = []
+    for m in models:
+        out = False
+        for i in weekly_test_only:
+            if i in m:
+                out = True
+                break
+        if not out:
+            ret_models.append(m)
+    return ret_models
+
 if __name__ == "__main__":
     args = parse_args()
 
@@ -361,12 +381,13 @@ if __name__ == "__main__":
         models = find_files("*.stan", args.directories)
         models = filter(model_name_re.match, models)
         models = list(filter(lambda m: not m in bad_models, models))
+        models = filter_out_weekly_models(models)
         num_samples = [args.num_samples or default_num_samples] * len(models)
     else:
         models, num_samples = read_tests(args.tests, args.num_samples or default_num_samples)
+        models = filter_out_weekly_models(models)
         if args.num_samples:
             num_samples = [args.num_samples] * len(models)
-
 
     executables = [m[:-5] for m in models]
     if args.scorch:


### PR DESCRIPTION
This PR does the following: 
- makes runPerformanceTests.py work on Windows
- ignores the huge distribution models by default (used in Integration tests) and an option to compile all if needed

For example of succesful runs with this changes see https://jenkins.mc-stan.org/blue/organizations/jenkins/Stan/detail/PR-3040/8/pipeline

