### PR TITLE
Move ci to flatiron institute

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,9 @@
 [submodule "cmdstan"]
 	path = cmdstan
-	url = https://github.com/stan-dev/cmdstan
+	url = https://github.com/stan-dev/cmdstan.git
 [submodule "example-models"]
 	path = example-models
-	url = https://github.com/stan-dev/example-models
+	url = https://github.com/stan-dev/example-models.git
 [submodule "stat_comp_benchmarks"]
 	path = stat_comp_benchmarks
 	url = https://github.com/stan-dev/stat_comp_benchmarks.git

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,6 +166,7 @@ pipeline {
                           userRemoteConfigs: [[url: "https://github.com/stan-dev/performance-tests-cmdstan.git",
                                                credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b'
                     ]]])
+                stash 'PerfSetup'
             }
         }
         stage('Gather machine information') {
@@ -271,17 +272,19 @@ pipeline {
 //             }
 //         }
         stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                    reuseNode true
-                }
-            }
+//             agent {
+//                 docker {
+//                     image 'stanorg/ci:gpu'
+//                     label 'linux'
+//                     reuseNode true
+//                 }
+//             }
+            agent { label 'osx' }
             when { branch 'master' }
             steps {
-                writeFile(file: "cmdstan/make/local", text: "CXXFLAGS += -march=core2")
-                sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+               unstash "PerfSetup"
+               writeFile(file: "cmdstan/make/local", text: "CXXFLAGS += -march=core2")
+               sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
             }
         }
         stage('Shotgun Performance Regression Tests') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -128,7 +128,7 @@ def post_comment(text, repository, pr_number, blue_ocean_repository) {
 }
 
 pipeline {
-    agent { label 'gelman-group-mac' }
+    agent { label 'osx' }
     environment {
         cmdstan_pr = ""
         GITHUB_TOKEN = credentials('6e7c1e8f-ca2c-4b11-a70e-d934d3f6b681')
@@ -156,7 +156,7 @@ pipeline {
                                         reference: '',
                                         trackingSubmodules: false]],
                           submoduleCfg: [],
-                          userRemoteConfigs: [[url: "git@github.com:stan-dev/performance-tests-cmdstan.git",
+                          userRemoteConfigs: [[url: "https://github.com/stan-dev/performance-tests-cmdstan.git",
                                                credentialsId: 'a630aebc-6861-4e69-b497-fd7f496ec46b'
                     ]]])
             }
@@ -300,11 +300,11 @@ pipeline {
                 }
             }
         }
-        unstable {
-            script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com, serban.nicusor@toptal.com") }
-        }
-        failure {
-            script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com, serban.nicusor@toptal.com") }
-        }
+//         unstable {
+//             script { utils.mailBuildResults("UNSTABLE", "stan-buildbot@googlegroups.com, serban.nicusor@toptal.com") }
+//         }
+//         failure {
+//             script { utils.mailBuildResults("FAILURE", "stan-buildbot@googlegroups.com, serban.nicusor@toptal.com") }
+//         }
     }
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -247,29 +247,29 @@ pipeline {
 //                 }
 //             }
 //         }
-        stage("Test cmdstan develop against cmdstan pointer in this branch") {
-            agent {
-                docker {
-                    image 'stanorg/ci:gpu'
-                    label 'linux'
-                    reuseNode true
-                }
-            }
-            //when { not { branch 'master' } }
-            steps {
-                script{
-                        cmdstan_pr = branchOrPR(params.cmdstan_pr)
-
-                        sh """
-                            old_hash=\$(git submodule status | grep cmdstan | awk '{print \$1}')
-                            cmdstan_hash=\$(if [ -n "${cmdstan_pr}" ]; then echo "${cmdstan_pr}"; else echo "\$old_hash" ; fi)
-                            bash compare-git-hashes.sh stat_comp_benchmarks develop \$cmdstan_hash ${branchOrPR(params.stan_pr)} ${branchOrPR(params.math_pr)}
-                            mv performance.xml \$cmdstan_hash.xml
-                            make revert clean
-                        """
-                }
-            }
-        }
+//         stage("Test cmdstan develop against cmdstan pointer in this branch") {
+//             agent {
+//                 docker {
+//                     image 'stanorg/ci:gpu'
+//                     label 'linux'
+//                     reuseNode true
+//                 }
+//             }
+//             //when { not { branch 'master' } }
+//             steps {
+//                 script{
+//                         cmdstan_pr = branchOrPR(params.cmdstan_pr)
+//
+//                         sh """
+//                             old_hash=\$(git submodule status | grep cmdstan | awk '{print \$1}')
+//                             cmdstan_hash=\$(if [ -n "${cmdstan_pr}" ]; then echo "${cmdstan_pr}"; else echo "\$old_hash" ; fi)
+//                             bash compare-git-hashes.sh stat_comp_benchmarks develop \$cmdstan_hash ${branchOrPR(params.stan_pr)} ${branchOrPR(params.math_pr)}
+//                             mv performance.xml \$cmdstan_hash.xml
+//                             make revert clean
+//                         """
+//                 }
+//             }
+//         }
         stage("Numerical Accuracy and Performance Tests on Known-Good Models") {
             agent {
                 docker {
@@ -281,7 +281,7 @@ pipeline {
             when { branch 'master' }
             steps {
                 writeFile(file: "cmdstan/make/local", text: "CXXFLAGS += -march=core2")
-                sh "./runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
+                sh "python3 runPerformanceTests.py --runs 3 --check-golds --name=known_good_perf --tests-file=known_good_perf_all.tests"
             }
         }
         stage('Shotgun Performance Regression Tests') {

--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -1,1 +1,14 @@
 stat_comp_benchmarks/benchmarks/arK/arK.stan
+stat_comp_benchmarks/benchmarks/arma/arma.stan
+stat_comp_benchmarks/benchmarks/eight_schools/eight_schools.stan
+stat_comp_benchmarks/benchmarks/garch/garch.stan
+stat_comp_benchmarks/benchmarks/gp_pois_regr/gp_pois_regr.stan
+stat_comp_benchmarks/benchmarks/gp_regr/gen_gp_data.stan
+stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan
+stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
+stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
+stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
+stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
+stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
+stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
+stat_comp_benchmarks/benchmarks/sir/sir.stan

--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -1,1 +1,14 @@
+stat_comp_benchmarks/benchmarks/arK/arK.stan
+stat_comp_benchmarks/benchmarks/arma/arma.stan
+stat_comp_benchmarks/benchmarks/eight_schools/eight_schools.stan
+stat_comp_benchmarks/benchmarks/garch/garch.stan
+stat_comp_benchmarks/benchmarks/gp_pois_regr/gp_pois_regr.stan
+stat_comp_benchmarks/benchmarks/gp_regr/gen_gp_data.stan
+stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan
+stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
+stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
+stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
 stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
+stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
+stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
+stat_comp_benchmarks/benchmarks/sir/sir.stan

--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -1,14 +1,1 @@
-stat_comp_benchmarks/benchmarks/arK/arK.stan
-stat_comp_benchmarks/benchmarks/arma/arma.stan
-stat_comp_benchmarks/benchmarks/eight_schools/eight_schools.stan
-stat_comp_benchmarks/benchmarks/garch/garch.stan
-stat_comp_benchmarks/benchmarks/gp_pois_regr/gp_pois_regr.stan
-stat_comp_benchmarks/benchmarks/gp_regr/gen_gp_data.stan
-stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan
-stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
-stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
-stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
 stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
-stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
-stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
-stat_comp_benchmarks/benchmarks/sir/sir.stan

--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -1,14 +1,1 @@
 stat_comp_benchmarks/benchmarks/arK/arK.stan
-stat_comp_benchmarks/benchmarks/arma/arma.stan
-stat_comp_benchmarks/benchmarks/eight_schools/eight_schools.stan
-stat_comp_benchmarks/benchmarks/garch/garch.stan
-stat_comp_benchmarks/benchmarks/gp_pois_regr/gp_pois_regr.stan
-stat_comp_benchmarks/benchmarks/gp_regr/gen_gp_data.stan
-stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan
-stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
-stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
-stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
-stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
-stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
-stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
-stat_comp_benchmarks/benchmarks/sir/sir.stan

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -169,7 +169,9 @@ def csv_summary(csv_file):
     d = defaultdict(list)
     print("--- --- --- --- ---")
     print(csv_file)
-    print(list)
+    if csv_file == "golds/example-models_regression_tests_mother.gold.tmp":
+        with open('golds/example-models_regression_tests_mother.gold.tmp', 'r') as f:
+            print(f.read())
     print("--- --- --- --- ---")
     with open(csv_file, 'rb') as raw:
         headers = None

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -167,13 +167,7 @@ def stdev(coll, mean):
 
 def csv_summary(csv_file):
     d = defaultdict(list)
-    print("--- --- --- --- ---")
-    print(csv_file)
-    if csv_file == "golds/example-models_regression_tests_mother.gold.tmp":
-        with open('golds/example-models_regression_tests_mother.gold.tmp', 'r') as f:
-            print(f.read())
-    print("--- --- --- --- ---")
-    with open(csv_file, 'rb') as raw:
+    with open(csv_file, 'rb', encoding = 'utf-8') as raw:
         headers = None
         for row in csv.reader(raw):
             if row[0].startswith("#"):

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -167,7 +167,7 @@ def stdev(coll, mean):
 
 def csv_summary(csv_file):
     d = defaultdict(list)
-    with open(csv_file, 'rb', encoding = 'utf-8') as raw:
+    with open(csv_file, 'r', encoding = 'utf-8') as raw:
         headers = None
         for row in csv.reader(raw):
             if row[0].startswith("#"):

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -167,6 +167,10 @@ def stdev(coll, mean):
 
 def csv_summary(csv_file):
     d = defaultdict(list)
+    print("--- --- --- --- ---")
+    print(csv_file)
+    print(list)
+    print("--- --- --- --- ---")
     with open(csv_file, 'rb') as raw:
         headers = None
         for row in csv.reader(raw):


### PR DESCRIPTION
## Summary

This PR will handle Jenkins CI migration to Flatiron Institute. Currently, WIP until we iron out errors, plugins, and other requirements.

PR is modifying the Jenkinsfile to accommodate Flatiron configuration and also changed runPerformanceTests.py to open .csv in read mode not in binary mode.

## Tests

We will run mc-stan and flatiron Jenkins in parallel until it's stable and most of the main jobs are workings, after that, we will decommission mc-stan and migrate entirely to Flatiron Institute.

## Side Effects

There may be side effects where two jobs would try to do the same objective like updating a submodule, will try to avoid this as much as possible.

## Release notes

## Copyright and Licensing


- [ ] Copyright holder: Toptal

    The copyright holder is typically you or your assignee, such as a university or company. By submitting this pull request, the copyright holder is agreeing to the license the submitted work under the following licenses:
      - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
      - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
