### PR TITLE
Remove ill-fitting model from tests

### DIFF
--- a/known_good_perf_all.tests
+++ b/known_good_perf_all.tests
@@ -8,7 +8,6 @@ stat_comp_benchmarks/benchmarks/gp_regr/gp_regr.stan
 stat_comp_benchmarks/benchmarks/irt_2pl/irt_2pl.stan
 stat_comp_benchmarks/benchmarks/low_dim_corr_gauss/low_dim_corr_gauss.stan, 20000
 stat_comp_benchmarks/benchmarks/low_dim_gauss_mix/low_dim_gauss_mix.stan
-stat_comp_benchmarks/benchmarks/low_dim_gauss_mix_collapse/low_dim_gauss_mix_collapse.stan
 stat_comp_benchmarks/benchmarks/pkpd/one_comp_mm_elim_abs.stan
 stat_comp_benchmarks/benchmarks/pkpd/sim_one_comp_mm_elim_abs.stan
 stat_comp_benchmarks/benchmarks/sir/sir.stan


### PR DESCRIPTION
This model is currently failing, but also features very seed-specific behavior and poor fits:


cmdstan 2.19, seed 1234: N_eff: 250+ (really poor Rhat though). seed 123: N_eff 12 with rhat 1
cmdstan 2.27, seed 1234: N_eff ~30. seed 123: N_eff ~9
cmdstan 2.29, seed 1234: N_eff: ~300. seed 123: N_eff: ~7
latest develop , seed 1234: N_eff ~3  seed 123: N_eff: ~10