### PR TITLE
Use docker label as now we can leverage both agents executors

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -142,7 +142,7 @@ def post_comment(text, repository, pr_number, blue_ocean_repository) {
 }
 
 pipeline {
-    agent { label 'linux && triqs' }
+    agent { label 'docker' }
     environment {
         cmdstan_pr = ""
         GITHUB_TOKEN = credentials('6e7c1e8f-ca2c-4b11-a70e-d934d3f6b681')
@@ -161,7 +161,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }
@@ -188,7 +188,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }
@@ -240,7 +240,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }
@@ -274,7 +274,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }
@@ -308,7 +308,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }
@@ -324,7 +324,7 @@ pipeline {
             agent {
                 docker {
                     image 'stanorg/ci:gpu'
-                    label 'linux'
+                    label 'docker'
                     reuseNode true
                 }
             }


### PR DESCRIPTION
When we migrated to Flatiron the second executor was not properly working with docker, I was having some issues with permissions because of the UID.
Now it seems to work fine so we can leverage both linux/docker agents.

Currently waiting for this build https://jenkins.flatironinstitute.org/blue/organizations/jenkins/Stan%2FCmdStan%20Performance%20Tests/detail/master/74/pipeline to confirm functionality.