### PR TITLE
Add script to only compile models

### DIFF
--- a/checkCompilation.py
+++ b/checkCompilation.py
@@ -1,0 +1,51 @@
+
+from cmdstan_perf_util import *
+import argparse
+import multiprocessing
+
+
+def read_tests(filename):
+    test_files = []
+    with open(filename) as f:
+        for line in f:
+            line = line.strip()
+            if not line or line.startswith("#"): continue
+            if ", " in line:
+                model, _ = line.split(", ")
+            else:
+                model = line
+            test_files.append(model)
+    return test_files
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Try the C++ compilation of the given directories.")
+    parser.add_argument("directories", nargs="*")
+    parser.add_argument("--syntax-only", dest="syntax_only", action="store_true", default=False)
+    parser.add_argument("-j", dest="j", action="store", type=int, default=multiprocessing.cpu_count())
+    parser.add_argument("--tests-file", dest="tests", action="store", type=str, default="")
+    return parser.parse_args()
+
+if __name__ == "__main__":
+    args = parse_args()
+
+    models = None
+
+    if args.tests == "":
+        models = find_files("*.stan", args.directories)
+    else:
+        models, _ = read_tests(args.tests)
+
+    executables = [m[:-5] for m in models]
+    delete_temporary_exe_files(executables)
+
+    try:
+        if args.syntax_only:
+            os.environ["CXXFLAGS"] = os.getenv("CXXFLAGS","") + " -fsyntax-only"
+            ext = ".o"
+        else:
+            ext = EXE_FILE_EXT
+
+        for batch in batched(executables):
+            make(batch, args.j, ext=ext, allow_failure=False)
+    finally:
+        delete_temporary_exe_files(executables)

--- a/cmdstan_perf_util.py
+++ b/cmdstan_perf_util.py
@@ -1,0 +1,88 @@
+import os
+import os.path
+from fnmatch import fnmatch
+from difflib import SequenceMatcher
+import subprocess
+import platform
+from time import time
+
+def isWin():
+    return platform.system().lower().startswith(
+        "windows"
+    ) or os.name.lower().startswith("windows")
+
+
+DIR_UP = os.path.join("..","")
+CURR_DIR = os.path.join(".","")
+SEP_RE = "\\\\" if os.sep == "\\" else "/"
+EXE_FILE_EXT = ".exe" if isWin() else ""
+
+def find_files(pattern, dirs):
+    res = []
+    for pd in dirs:
+        for d, _, flist in os.walk(pd):
+            for f in flist:
+                if fnmatch(f, pattern):
+                    res.append(os.path.join(d, f))
+    return res
+
+
+def str_dist(target):
+    def str_dist_internal(candidate):
+        return SequenceMatcher(None, candidate, target).ratio()
+    return str_dist_internal
+
+def closest_string(target, candidates):
+    if candidates:
+        return max(candidates, key=str_dist(target))
+
+
+
+def time_step(name, fn, *args, **kwargs):
+    start = time()
+    res = fn(*args, **kwargs)
+    end = time()
+    return end-start, res
+
+class FailedCommand(Exception):
+    def __init__(self, returncode, command):
+        self.returncode = returncode
+        self.command = command
+        Exception(self, "return code '{}' from command '{}'!"
+                  .format(returncode, command))
+
+
+def shexec(command, wd = "."):
+    print(command)
+    returncode = subprocess.call(command, shell=True, cwd=wd)
+    if returncode != 0:
+        raise FailedCommand(returncode, command)
+    return returncode
+
+def make(targets, j=8, ext=EXE_FILE_EXT, allow_failure=True):
+    for i in range(len(targets)):
+        prefix = ""
+        if not targets[i].startswith(os.sep):
+            prefix = DIR_UP
+        targets[i] = prefix + targets[i] + ext
+    try:
+        shexec("make -i -j{} {}"
+            .format(j, " ".join(targets)), wd = "cmdstan")
+    except FailedCommand:
+        if allow_failure:
+            print("Failed to make at least some targets")
+        else:
+            raise
+
+batchSize = 20 if isWin() else 200
+
+def batched(tests):
+    return [tests[i : i + batchSize] for i in range(0, len(tests), batchSize)]
+
+def delete_temporary_exe_files(exes):
+    for exe in exes:
+        extensions = ["", ".hpp", ".o"]
+        for ext in extensions:
+            print("Removing " + exe + ext)
+            if os.path.exists(exe + ext):
+                os.remove(exe + ext)


### PR DESCRIPTION
In both the stanc3 jenkinsfile and [bleeding-edge-monthly](https://github.com/stan-dev/ci-scripts/blob/master/Jenkinsfile-bleeding-edge-monthly) tests we re-use the performance tests script here to just check that a bunch of models compile. We don't need to run them, and the extra machinery in the runPerformanceTests.py file complicates things.

Splitting this out also lets us use the `-fsyntax-only` flag to Clang, which should skip the linker and overall make things much faster for stanc3 at least.