### PR TITLE
Make checkCompiles run on the same set of models

### DIFF
--- a/checkCompilation.py
+++ b/checkCompilation.py
@@ -23,17 +23,19 @@ def parse_args():
     parser.add_argument("--syntax-only", dest="syntax_only", action="store_true", default=False)
     parser.add_argument("-j", dest="j", action="store", type=int, default=multiprocessing.cpu_count())
     parser.add_argument("--tests-file", dest="tests", action="store", type=str, default="")
+    parser.add_argument("--even-slow-models", dest="slow_models", action="store_true")
     return parser.parse_args()
 
 if __name__ == "__main__":
     args = parse_args()
 
-    models = None
-
     if args.tests == "":
         models = find_files("*.stan", args.directories)
     else:
         models, _ = read_tests(args.tests)
+
+    if not args.slow_models:
+        models = filter_out_weekly_models(models)
 
     executables = [m[:-5] for m in models]
     delete_temporary_exe_files(executables)

--- a/checkCompilation.py
+++ b/checkCompilation.py
@@ -46,6 +46,8 @@ if __name__ == "__main__":
     else:
         ext = EXE_FILE_EXT
 
-    for batch in batched(executables):
-        make(batch, args.j, ext=ext, allow_failure=False)
-
+    try:
+        for batch in batched(executables):
+            make(batch, args.j, ext=ext, allow_failure=False)
+    finally:
+        delete_temporary_exe_files(executables)

--- a/cmdstan_perf_util.py
+++ b/cmdstan_perf_util.py
@@ -1,10 +1,29 @@
 import os
-import os.path
 from fnmatch import fnmatch
 from difflib import SequenceMatcher
 import subprocess
 import platform
 from time import time
+
+weekly_test_only = frozenset(
+    [os.path.join("good","function-signatures","distributions","univariate","continuous", "exp_mod_normal")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "pareto_type_2")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "skew_normal")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "student_t")
+     , os.path.join("good","function-signatures","distributions","univariate","continuous", "wiener")
+    ])
+
+def filter_out_weekly_models(models):
+    ret_models = []
+    for m in models:
+        out = False
+        for i in weekly_test_only:
+            if i in m:
+                out = True
+                break
+        if not out:
+            ret_models.append(m)
+    return ret_models
 
 def isWin():
     return platform.system().lower().startswith(
@@ -78,6 +97,8 @@ batchSize = 20 if isWin() else 200
 
 def batched(tests):
     return [tests[i : i + batchSize] for i in range(0, len(tests), batchSize)]
+
+
 
 def delete_temporary_exe_files(exes):
     for exe in exes:

--- a/runPerformanceTests.py
+++ b/runPerformanceTests.py
@@ -97,14 +97,6 @@ bad_models = frozenset(
      , os.path.join("example-models","BPA","Ch.07","cjs_group_raneff.stan")
     ])
 
-weekly_test_only = frozenset(
-    [os.path.join("good","function-signatures","distributions","univariate","continuous", "exp_mod_normal")
-     , os.path.join("good","function-signatures","distributions","univariate","continuous", "pareto_type_2")
-     , os.path.join("good","function-signatures","distributions","univariate","continuous", "skew_normal")
-     , os.path.join("good","function-signatures","distributions","univariate","continuous", "student_t")
-     , os.path.join("good","function-signatures","distributions","univariate","continuous", "wiener")
-    ])
-
 def csv_summary(csv_file):
     d = defaultdict(list)
     with open(csv_file, 'r', encoding = 'utf-8') as raw:
@@ -294,19 +286,6 @@ def process_test(overwrite, check_golds, check_golds_exact, runs, method):
         average_time = runs and time_ / runs or 0
         return (model, average_time, fails, errors)
     return process_test_wrapper
-
-
-def filter_out_weekly_models(models):
-    ret_models = []
-    for m in models:
-        out = False
-        for i in weekly_test_only:
-            if i in m:
-                out = True
-                break
-        if not out:
-            ret_models.append(m)
-    return ret_models
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
We had some models we were skipping by default in runPerformanceTests, and it turns out including them completely blows any advantage that using `-fsyntax-only` grants out of the water