### PR TITLE
Add test models specific to stanc3 optimizer

### DIFF
--- a/optimizer-stress-models/inline-tdata.stan
+++ b/optimizer-stress-models/inline-tdata.stan
@@ -1,0 +1,19 @@
+functions {
+  matrix foo(int N, int M){
+    return rep_matrix(1, N, M);
+  }
+}
+
+transformed data {
+   int N = 10;
+   int M = 11;
+   matrix[N,M] bar = foo(N, M);
+}
+
+parameters {
+  real alpha;
+}
+
+model {
+  sum(bar) ~ normal(alpha, 0.1);
+}

--- a/optimizer-stress-models/soa-index.stan
+++ b/optimizer-stress-models/soa-index.stan
@@ -1,0 +1,13 @@
+parameters {
+  vector[3] y;
+  array[3] vector[4] arr_vec;
+}
+transformed parameters {
+  vector[3] x = y[1 : 3];
+}
+model {
+  x ~ std_normal();
+  for (i in 1 : 3) {
+    arr_vec[i] ~ std_normal();
+  }
+}

--- a/optimizer.tests
+++ b/optimizer.tests
@@ -1,0 +1,2 @@
+optimizer-stress-models/inline-tdata.stan
+optimizer-stress-models/soa-index.stan, 1000


### PR DESCRIPTION
See #38 

This adds the models from https://github.com/stan-dev/stanc3/pull/1218 and https://github.com/stan-dev/stanc3/pull/1323

Which previously exhibited segmentation faults or poor runtime behavior when optimized. 