### PR TITLE
Make builds respect $PARALLEL setting

### DIFF
--- a/compare-compilers.sh
+++ b/compare-compilers.sh
@@ -14,7 +14,7 @@ fi
 set -e -x
 
 # run develop version of cmdstan with the nightly stanc3 binary
-cd cmdstan; make clean-all; make -j4 build; make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+cd cmdstan; make clean-all; make -j${PARALLEL:-4} build; make -j${PARALLEL:-4} examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
 ./runPerformanceTests.py --overwrite-golds $1
 
 for i in performance.*; do
@@ -22,7 +22,7 @@ for i in performance.*; do
 done
 
 # run develop version of cmdstan with the stanc3 binary at the provided path
-cd cmdstan; make clean-all; make -j4 build; cd ..
+cd cmdstan; make clean-all; make -j${PARALLEL:-4} build; cd ..
 rm cmdstan/bin/stanc
 cp "$2" cmdstan/bin/stanc
 cmdstan/bin/stanc --version

--- a/compare-optimizer.sh
+++ b/compare-optimizer.sh
@@ -14,12 +14,12 @@ fi
 set -e -x
 
 # run with the default optimization level
-cd cmdstan; make clean-all; make -j4 build;
+cd cmdstan; make clean-all; make -j${PARALLEL:-4} build;
 if [ -n "$3" ] ; then
     rm bin/stanc
     cp "$3" bin/stanc
 fi
-make -j4 examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
+make -j${PARALLEL:-4} examples/bernoulli/bernoulli; ./bin/stanc --version; cd ..
 ./runPerformanceTests.py --overwrite-golds $1
 
 for i in performance.*; do


### PR DESCRIPTION
These scripts are usually passed in -j args which are passed only to runPerformanceTests.py.  It might be better to parse these, but at least this sets it to a configurable number, that's already set in jenkins.

(Noticed this working on stanc3 jenkins migration, which calls these.)